### PR TITLE
Fix: Remove github-pages environment from Docker workflow

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -19,7 +19,6 @@ jobs:
   push_to_registries:
     name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
-    environment: github-pages
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
The workflow was looking for secrets in the github-pages environment instead of repository secrets, causing authentication failures.

Removed the 'environment: github-pages' line as it's not needed for Docker builds and was preventing access to repository-level secrets.