### PR TITLE
feat: Split Total Calories into two separate push values

### DIFF
--- a/SparkyFitnessMobile/src/services/healthConnectService.js
+++ b/SparkyFitnessMobile/src/services/healthConnectService.js
@@ -298,15 +298,31 @@ export const aggregateTotalCaloriesByDate = async (records) => {
   }, {});
 
   // Add BMR to each day's total
-  // Add BMR × 1.2 (sedentary TDEE) to each day's active calories
+  // Push two separate values per date:
+  // 1. Active Calories (exercise only) - for calorie goal subtraction
+  // 2. total_calories (exercise + BMR × 1.2) - for reports
   const sedentaryTDEE = bmrValue * 1.2;
-  const result = Object.keys(aggregatedData).map(date => ({
-    date,
-    value: aggregatedData[date] + sedentaryTDEE, // Add sedentary TDEE to active calories
-    type: 'Active Calories',
-  }));
+  const result = [];
 
-  addLog(`[HealthConnectService] Aggregated total calories data into ${result.length} daily entries (BMR × 1.2 + active = ${sedentaryTDEE.toFixed(0)} + active)`);
+  Object.keys(aggregatedData).forEach(date => {
+    const exerciseCalories = aggregatedData[date];
+
+    // Push Active Calories (exercise only) - for calorie goal subtraction
+    result.push({
+      date,
+      value: exerciseCalories,
+      type: 'Active Calories',
+    });
+
+    // Push total_calories (exercise + BMR × 1.2) - for reports
+    result.push({
+      date,
+      value: exerciseCalories + sedentaryTDEE,
+      type: 'total_calories',
+    });
+  });
+
+  addLog(`[HealthConnectService] Aggregated total calories data into ${result.length} entries: ${result.length/2} days with both Active Calories (exercise only) and total_calories (exercise + BMR × 1.2 = ${sedentaryTDEE.toFixed(0)})`);
   return result;
 };
 
@@ -426,12 +442,12 @@ export const transformHealthRecords = (records, metricConfig) => {
             break;
 
           case 'TotalCaloriesBurned':
-            if (record.value !== undefined && record.date && record.type === 'Active Calories') {
+            if (record.value !== undefined && record.date && (record.type === 'Active Calories' || record.type === 'total_calories')) {
               // Already aggregated and converted to kcal
               value = record.value;
               recordDate = record.date;
               if (index === 0) {
-                addLog(`[Transform] TotalCalories (aggregated): ${value} kcal on ${recordDate}`, 'debug');
+                addLog(`[Transform] TotalCalories (aggregated as ${record.type}): ${value} kcal on ${recordDate}`, 'debug');
               }
             } else if (record.startTime && record.energy?.inCalories != null) {
               // Raw record - convert from calories to kilocalories


### PR DESCRIPTION
Modified aggregateTotalCaloriesByDate to push two separate values per date:
1. "Active Calories" - exercise calories only (for calorie goal subtraction)
2. "total_calories" - exercise + BMR × 1.2 (for reports and total expenditure tracking)

This allows the calorie goal to be reduced by exercise calories only, while still tracking the full TDEE calculation in reports.

Changes:
- aggregateTotalCaloriesByDate: Now returns 2 entries per date
- transformHealthRecords: Updated condition to handle both 'Active Calories' and 'total_calories' types