### PR TITLE
Fix: Preserve original type from aggregated TotalCaloriesBurned records

### DIFF
--- a/SparkyFitnessMobile/src/services/healthConnectService.js
+++ b/SparkyFitnessMobile/src/services/healthConnectService.js
@@ -393,6 +393,7 @@ export const transformHealthRecords = (records, metricConfig) => {
     try {
       let value = null;
       let recordDate = null;
+      let outputType = type; // Default to metricConfig type, but can be overridden
 
       if (['Steps', 'HeartRate', 'ActiveCaloriesBurned', 'TotalCaloriesBurned'].includes(recordType)) {
         if (record.value !== undefined && record.date) {
@@ -446,6 +447,7 @@ export const transformHealthRecords = (records, metricConfig) => {
               // Already aggregated and converted to kcal
               value = record.value;
               recordDate = record.date;
+              outputType = record.type; // Preserve the original type from aggregated data
               if (index === 0) {
                 addLog(`[Transform] TotalCalories (aggregated as ${record.type}): ${value} kcal on ${recordDate}`, 'debug');
               }
@@ -913,7 +915,7 @@ export const transformHealthRecords = (records, metricConfig) => {
       if (value !== null && value !== undefined && !isNaN(value) && recordDate) {
         transformedData.push({
           value: parseFloat(value.toFixed(2)),
-          type: type,
+          type: outputType,
           date: recordDate,
           unit: unit,
         });


### PR DESCRIPTION
The transform function was using the metricConfig type for all records, causing both 'Active Calories' and 'total_calories' entries to be pushed as 'Active Calories'. This resulted in the server receiving duplicate "Active Calories" entries that were summed together incorrectly.

Now the transform function:
- Defaults to using metricConfig type (outputType = type)
- For TotalCaloriesBurned aggregated records, preserves the original type from the record (outputType = record.type)
- Pushes records with the correct outputType

This ensures:
- 'Active Calories' entries (exercise only) are pushed as "Active Calories"
- 'total_calories' entries (exercise + BMR × 1.2) are pushed as "total_calories"