### PR TITLE
Fix: Preserve type in early aggregated records check

### DIFF
--- a/SparkyFitnessMobile/src/services/healthConnectService.js
+++ b/SparkyFitnessMobile/src/services/healthConnectService.js
@@ -399,6 +399,10 @@ export const transformHealthRecords = (records, metricConfig) => {
         if (record.value !== undefined && record.date) {
           value = record.value;
           recordDate = record.date;
+          // Preserve the type from aggregated records (e.g., 'Active Calories' or 'total_calories')
+          if (record.type) {
+            outputType = record.type;
+          }
         }
       } else {
         switch (recordType) {


### PR DESCRIPTION
The transform function has an early check for aggregated records at line 398 that extracts value and date, but wasn't preserving the outputType from the record. This caused both 'Active Calories' and 'total_calories' entries to be pushed with the default metricConfig type ('Active Calories').

The switch statement at line 428 with `outputType = record.type` was never reached because the early check already handled the record and skipped the else/switch block.

Now the early check also preserves outputType when record.type exists, ensuring:
- Records with type 'Active Calories' are pushed as "Active Calories"
- Records with type 'total_calories' are pushed as "total_calories"