### PR TITLE
Fix: Display only total_calories in Total Calories metric UI

### DIFF
--- a/SparkyFitnessMobile/src/screens/MainScreen.js
+++ b/SparkyFitnessMobile/src/screens/MainScreen.js
@@ -156,7 +156,10 @@ const fetchHealthData = async (currentHealthMetricStates, timeRange) => {
 
           case 'TotalCaloriesBurned':
             const aggregatedTotalCalories = await aggregateTotalCaloriesByDate(records);
-            const totalCaloriesSum = aggregatedTotalCalories.reduce((sum, record) => sum + record.value, 0);
+            // Filter to only include 'total_calories' entries, excluding 'Active Calories' entries
+            const totalCaloriesSum = aggregatedTotalCalories
+              .filter(record => record.type === 'total_calories')
+              .reduce((sum, record) => sum + record.value, 0);
             // Convert from calories to kilocalories (divide by 1000)
             displayValue = Math.round(totalCaloriesSum).toLocaleString();
             break;


### PR DESCRIPTION
The Total Calories metric was displaying the sum of both 'Active Calories' and 'total_calories' entries returned by aggregateTotalCaloriesByDate, resulting in incorrect values (e.g., 251 + 2293.4 = 2544.4).

Now filters to only display 'total_calories' entries (exercise + BMR × 1.2) while still pushing both values to the server:
- 'Active Calories' for calorie goal subtraction
- 'total_calories' for reports and TDEE tracking

This ensures the Android app UI shows the correct total daily energy expenditure without double-counting.