### PR TITLE
Add automatic redirect retry to handle browser cache

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/useAuth.tsx
+++ b/SparkyFitnessFrontend/src/hooks/useAuth.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { REDIRECT_TRACKING_KEY } from '@/services/api';
+import { REDIRECT_TRACKING_KEY, cancelScheduledRedirect } from '@/services/api';
 
 interface User {
   id: string;
@@ -39,6 +39,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
               // Clear redirect tracking timestamp when successfully authenticated
               // This ensures the next session expiration can trigger a redirect
               localStorage.removeItem(REDIRECT_TRACKING_KEY);
+              cancelScheduledRedirect(); // Cancel any pending redirect
               console.debug('Cleared redirect tracking - OIDC session is valid');
             }
           } else if (oidcResponse.status === 401 || oidcResponse.status === 403) {
@@ -64,6 +65,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                 // Clear redirect tracking timestamp when successfully authenticated
                 // This ensures the next session expiration can trigger a redirect
                 localStorage.removeItem(REDIRECT_TRACKING_KEY);
+                cancelScheduledRedirect(); // Cancel any pending redirect
                 console.debug('Cleared redirect tracking - password session is valid');
               }
             } else if (passwordResponse.status === 401 || passwordResponse.status === 403) {
@@ -137,6 +139,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     // Clear redirect tracking timestamp when user signs in
     // This ensures the next session expiration can trigger a redirect
     localStorage.removeItem(REDIRECT_TRACKING_KEY);
+    cancelScheduledRedirect(); // Cancel any pending redirect
     console.debug('Cleared redirect tracking - user signed in via', authType);
   };
 


### PR DESCRIPTION
The previous implementation had a critical UX issue: when the page loaded from browser cache (regular F5 refresh), the redirect would be skipped and users would be stuck on an error screen. This required users to do a hard refresh (Ctrl+Shift+R) which is not acceptable for production.

Root cause:
- window.location.replace('/') happens so fast (~171ms)
- Page loads from cache with old timestamp still fresh
- Code sees "last redirect was 727ms ago" → skips redirect
- User stuck seeing "Network Error" with no auto-recovery

Solution: Auto-retry after timeout
- When redirect is skipped due to recent timestamp, calculate remaining time
- Schedule automatic redirect using setTimeout after that time passes
- Example: Last redirect 727ms ago, threshold 3000ms → schedule in 2273ms
- User sees automatic redirect without any manual intervention

Changes:
1. Added scheduledRedirectTimeout to track pending redirects
2. Created performRedirectToLogin() function to avoid code duplication
3. Added cancelScheduledRedirect() export to cancel pending redirects
4. When skipping immediate redirect, schedule automatic retry
5. Clear scheduled timeout when authentication succeeds
6. Prevent multiple scheduled redirects with timeout tracking

Flow now:
- Session expires → NetworkError detected
- If >3s since last: redirect immediately
- If <3s since last: schedule redirect in remaining time
- User waits ~2s → automatic redirect fires → Authentik intercepts
- Works on all platforms: iOS, Android, Windows, no keyboard shortcuts needed

This ensures seamless user experience across all browsers and platforms without requiring hard refreshes or manual intervention.