### PR TITLE
Add cache-busting parameter to force Authentik interception

### DIFF
--- a/SparkyFitnessFrontend/src/services/api.ts
+++ b/SparkyFitnessFrontend/src/services/api.ts
@@ -76,18 +76,19 @@ function performRedirectToLogin() {
     variant: "destructive",
   });
 
-  // Navigate to root path to trigger Authentik intercept
-  // Using replace() instead of reload() to force a full navigation
-  // This allows Authentik proxy to intercept the request and redirect to login
+  // Navigate to root path with cache-busting parameter to force Authentik intercept
+  // The cache-busting parameter forces a network request instead of serving from cache
+  // This ensures Authentik proxy can intercept the request and redirect to login
+  const cacheBustUrl = `/?_auth=${now}`;
   try {
-    warn(userLoggingLevel, 'Calling window.location.replace(\'/\') to force Authentik intercept');
-    // Replace current page with root (no history entry)
-    window.location.replace('/');
+    warn(userLoggingLevel, `Calling window.location.replace('${cacheBustUrl}') to force Authentik intercept`);
+    // Replace current page with root + cache buster (no history entry, forces network request)
+    window.location.replace(cacheBustUrl);
   } catch (replaceError) {
     // If replace fails, try href as fallback
     warn(userLoggingLevel, 'Replace failed, trying window.location.href');
     try {
-      window.location.href = '/';
+      window.location.href = cacheBustUrl;
     } catch (hrefError) {
       // Last resort - reload
       warn(userLoggingLevel, 'href failed, trying window.location.reload()');


### PR DESCRIPTION
The scheduled redirect was firing correctly, but the browser was serving the page from cache instead of making a network request, preventing Authentik from intercepting and redirecting to login.

Root cause:
- window.location.replace('/') navigates to root
- Browser checks cache → finds React SPA cached
- Serves from cache in ~182ms (no network request!)
- Authentik never sees the request → cannot intercept
- Loop continues: redirect fires → cache served → redirect fires → cache served

Evidence from logs:
```
SPARKY AUTH: Executing scheduled redirect
Gewechselt zu https://sparky.kraleo.stream/
Keeping recent redirect timestamp (182ms old) - will clear after 3s
SPARKY AUTH: NetworkError detected. Last redirect: 796ms ago
SPARKY AUTH: Scheduling automatic redirect in 2204ms
```

The timestamp shows page loaded in 182ms (cache), then scheduled another redirect after detecting NetworkError again.

Solution: Cache-busting query parameter
- Changed from: window.location.replace('/')
- Changed to: window.location.replace('/?_auth=<timestamp>')
- The unique query parameter forces browser to treat as new URL
- Browser MUST make network request (cache miss)
- Authentik proxy intercepts the network request
- User redirected to login successfully

How it works:
1. Session expires → NetworkError
2. Code calls: window.location.replace('/?_auth=1731456789123')
3. Browser sees new URL (not in cache)
4. Makes network request to server
5. Authentik intercepts → redirects to login ✓

This should finally work on all browsers without hard refresh:
- iOS Safari (no hard refresh option)
- Android Firefox
- Windows Firefox
- Regular F5 refresh