### PR TITLE
Fix iOS Service Worker issue: Navigate immediately instead of reload

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/useAuth.tsx
+++ b/SparkyFitnessFrontend/src/hooks/useAuth.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
-import { REDIRECT_TRACKING_KEY, cancelScheduledRedirect } from '@/services/api';
+import { REDIRECT_TRACKING_KEY, SW_UNREGISTERED_KEY, cancelScheduledRedirect } from '@/services/api';
 
 interface User {
   id: string;
@@ -39,6 +39,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
               // Clear redirect tracking timestamp when successfully authenticated
               // This ensures the next session expiration can trigger a redirect
               localStorage.removeItem(REDIRECT_TRACKING_KEY);
+              localStorage.removeItem(SW_UNREGISTERED_KEY);
               cancelScheduledRedirect(); // Cancel any pending redirect
               console.debug('Cleared redirect tracking - OIDC session is valid');
             }
@@ -65,6 +66,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                 // Clear redirect tracking timestamp when successfully authenticated
                 // This ensures the next session expiration can trigger a redirect
                 localStorage.removeItem(REDIRECT_TRACKING_KEY);
+                localStorage.removeItem(SW_UNREGISTERED_KEY);
                 cancelScheduledRedirect(); // Cancel any pending redirect
                 console.debug('Cleared redirect tracking - password session is valid');
               }
@@ -139,6 +141,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     // Clear redirect tracking timestamp when user signs in
     // This ensures the next session expiration can trigger a redirect
     localStorage.removeItem(REDIRECT_TRACKING_KEY);
+    localStorage.removeItem(SW_UNREGISTERED_KEY);
     cancelScheduledRedirect(); // Cancel any pending redirect
     console.debug('Cleared redirect tracking - user signed in via', authType);
   };


### PR DESCRIPTION
The previous approach of reloading after unregistering Service Workers didn't work on iOS because:
1. Reload would bring us back to the same page
2. Service Worker might re-register before we could navigate
3. This created a loop where SW was always present

New approach:
1. Unregister Service Workers (if present)
2. Wait 500ms for iOS WebKit to complete unregistration
3. Navigate directly to /?_auth=timestamp (no reload)
4. Use location.href instead of location.replace (better iOS compatibility)

Changes:
- Removed the early return and reload logic
- Both paths (with or without SW) now navigate to /?_auth=...
- Increased delay from 200ms to 500ms for iOS
- Use location.href instead of location.replace
- Added SW_UNREGISTERED_KEY flag for future use
- Clear SW_UNREGISTERED_KEY when auth succeeds

Why this works:
- No reload = no chance for SW to re-register
- Direct navigation with 500ms delay gives WebKit time to unregister
- location.href works more reliably on iOS WebKit than replace()
- Cache-busting URL ensures fresh network request

This should fix the "FetchEvent.respondWith received an error" on iOS by ensuring the Service Worker is fully inactive before Authentik tries to handle the authentication flow.