### PR TITLE
Prevent Service Worker re-registration during auth flow

### DIFF
--- a/SparkyFitnessFrontend/index.html
+++ b/SparkyFitnessFrontend/index.html
@@ -35,9 +35,20 @@
         <script>
             if ("serviceWorker" in navigator) {
                 window.addEventListener("load", () => {
+                    // Check if we're in the middle of unregistering SW for auth flow
+                    // If SW_UNREGISTERED_KEY is set, skip registration to allow clean Authentik redirect
+                    const swUnregistered = localStorage.getItem('sparky_sw_unregistered');
+
+                    if (swUnregistered) {
+                        console.log('SW registration skipped - auth flow in progress');
+                        return; // Don't re-register, let auth flow complete
+                    }
+
                     navigator.serviceWorker
                         .register("/sw.js")
-                        .then((registration) => {})
+                        .then((registration) => {
+                            console.log('SW registered successfully');
+                        })
                         .catch((registrationError) => {
                             console.log(
                                 "SW registration failed: ",


### PR DESCRIPTION
Root cause of iOS infinite loop identified:
The Service Worker was being unconditionally re-registered on every page load (index.html lines 36-48), even after we unregistered it.

The broken flow:
1. Session expires → Unregister SW → Set flag → Reload
2. Page loads → index.html runs → SW RE-REGISTERS immediately
3. Session check fails → Detect SW again → Unregister → Loop forever

This is why iOS kept showing "Load failed" - the SW was always there intercepting Authentik requests, even though we kept unregistering it.

The fix:
Check SW_UNREGISTERED_KEY flag in index.html BEFORE registering SW. If flag is set, skip registration to allow auth flow to complete.

New flow:
1. Session expires → Unregister SW → Set flag → Reload
2. Page loads → Check flag → SKIP SW registration
3. No SW present → Navigate to '/' → Authentik intercepts cleanly
4. After login → Clear flag → SW can register again next session

Changes to index.html:
- Check localStorage for 'sparky_sw_unregistered' before registration
- If present, return early and skip SW registration
- Log message for debugging

This prevents the SW from interfering with Authentik authentication on iOS while still allowing it to work normally during regular use.

Should finally fix iOS logout/re-login!