### PR TITLE
Prevent Service Worker re-registration during auth flow

### DIFF
--- a/SparkyFitnessFrontend/index.html
+++ b/SparkyFitnessFrontend/index.html
@@ -44,6 +44,15 @@
                         return; // Don't re-register, let auth flow complete
                     }
 
+                    // Only register Service Worker if user has been authenticated before
+                    // This prevents SW from interfering with Authentik's initial login flow
+                    const userWasAuthenticated = localStorage.getItem('sparky_user_was_authenticated');
+
+                    if (!userWasAuthenticated) {
+                        console.log('SW registration skipped - user not yet authenticated (fresh session)');
+                        return; // Don't register SW until after first login
+                    }
+
                     navigator.serviceWorker
                         .register("/sw.js")
                         .then((registration) => {

--- a/SparkyFitnessFrontend/src/hooks/useAuth.tsx
+++ b/SparkyFitnessFrontend/src/hooks/useAuth.tsx
@@ -40,6 +40,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
               // This ensures the next session expiration can trigger a redirect
               localStorage.removeItem(REDIRECT_TRACKING_KEY);
               localStorage.removeItem(SW_UNREGISTERED_KEY);
+              // Mark that user has been authenticated - allows Service Worker registration
+              localStorage.setItem('sparky_user_was_authenticated', 'true');
+
+              // Register Service Worker now that user is authenticated
+              if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.register('/sw.js').catch((err) => {
+                  console.warn('SW registration after auth failed:', err);
+                });
+              }
+
               cancelScheduledRedirect(); // Cancel any pending redirect
               console.debug('Cleared redirect tracking - OIDC session is valid');
             }
@@ -67,6 +77,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                 // This ensures the next session expiration can trigger a redirect
                 localStorage.removeItem(REDIRECT_TRACKING_KEY);
                 localStorage.removeItem(SW_UNREGISTERED_KEY);
+                // Mark that user has been authenticated - allows Service Worker registration
+                localStorage.setItem('sparky_user_was_authenticated', 'true');
+
+                // Register Service Worker now that user is authenticated
+                if ('serviceWorker' in navigator) {
+                  navigator.serviceWorker.register('/sw.js').catch((err) => {
+                    console.warn('SW registration after auth failed:', err);
+                  });
+                }
+
                 cancelScheduledRedirect(); // Cancel any pending redirect
                 console.debug('Cleared redirect tracking - password session is valid');
               }
@@ -142,6 +162,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     // This ensures the next session expiration can trigger a redirect
     localStorage.removeItem(REDIRECT_TRACKING_KEY);
     localStorage.removeItem(SW_UNREGISTERED_KEY);
+    // Mark that user has been authenticated - allows Service Worker registration
+    localStorage.setItem('sparky_user_was_authenticated', 'true');
+
+    // Register Service Worker now that user is authenticated
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js').catch((err) => {
+        console.warn('SW registration after auth failed:', err);
+      });
+    }
+
     cancelScheduledRedirect(); // Cancel any pending redirect
     console.debug('Cleared redirect tracking - user signed in via', authType);
   };


### PR DESCRIPTION
Root cause of fresh incognito iOS breakage:
On fresh incognito load, the Service Worker was being registered immediately by index.html BEFORE Authentik could handle authentication. This caused SW to intercept Authentik's redirect, leading to: "FetchEvent.respondWith received an error: TypeError: Load failed"

The problem flow:
1. Fresh incognito → Load page
2. index.html runs → Service Worker registers immediately
3. Authentik tries to redirect to /outpost.goauthentik.io/starts...
4. Service Worker intercepts Authentik's auth redirect
5. SW can't handle it → "Load failed" error

The solution: Conditional SW registration based on auth state

Only register Service Worker AFTER user has authenticated at least once. This prevents SW from interfering with Authentik's initial login flow.

Changes to index.html:
- Added check for 'sparky_user_was_authenticated' flag
- If flag not present → Skip SW registration (fresh session)
- If flag present → Register SW normally (returning user)

Changes to useAuth.tsx:
- Set 'sparky_user_was_authenticated' flag on successful auth
- Immediately register SW after setting flag (for current session)
- Added to all three auth success paths: OIDC, password, signIn

New flow (fresh incognito):
1. Load page → No SW registered (flag not set)
2. Authentik intercepts cleanly → redirects to login
3. User logs in → Authentik redirects back
4. Auth succeeds → Set flag → Register SW
5. SW now available for offline/caching features

Logout/re-login flow:
1. Logout → Flag persists (user was authenticated)
2. Session expires → SW may be present
3. Unregister SW → Reload → Navigate
4. Authentik intercepts → Login again
5. Auth succeeds → SW re-registers

This should finally fix iOS fresh incognito while maintaining functionality for returning users!