### PR TITLE
Add display_name field to custom categories for aliasing

### DIFF
--- a/SparkyFitnessFrontend/src/components/CheckIn.tsx
+++ b/SparkyFitnessFrontend/src/components/CheckIn.tsx
@@ -157,7 +157,7 @@ const CheckIn = () => {
           entry_timestamp: m.entry_timestamp,
           value: m.value,
           type: 'custom',
-          display_name: m.custom_categories.name,
+          display_name: m.custom_categories.display_name || m.custom_categories.name,
           display_unit: m.custom_categories.measurement_type,
           custom_categories: m.custom_categories, // Keep original custom_categories for conversion logic
         };
@@ -707,7 +707,7 @@ const CheckIn = () => {
                 return (
                   <div key={category.id}>
                     <Label htmlFor={`custom-${category.id}`}>
-                      {category.name} ({isConvertible ? defaultMeasurementUnit : category.measurement_type})
+                      {category.display_name || category.name} ({isConvertible ? defaultMeasurementUnit : category.measurement_type})
                     </Label>
                     <Input
                       id={`custom-${category.id}`}
@@ -720,7 +720,7 @@ const CheckIn = () => {
                           [category.id]: e.target.value
                         }));
                       }}
-                      placeholder={t('checkIn.enterCustomCategory', { categoryName: category.name.toLowerCase(), defaultValue: `Enter ${category.name.toLowerCase()}` })}
+                      placeholder={t('checkIn.enterCustomCategory', { categoryName: (category.display_name || category.name).toLowerCase(), defaultValue: `Enter ${(category.display_name || category.name).toLowerCase()}` })}
                     />
                     <Input
                       id={`custom-notes-${category.id}`}

--- a/SparkyFitnessFrontend/src/components/CustomCategoryManager.tsx
+++ b/SparkyFitnessFrontend/src/components/CustomCategoryManager.tsx
@@ -34,6 +34,7 @@ const CustomCategoryManager = ({ categories, onCategoriesChange }: CustomCategor
   const [editingCategory, setEditingCategory] = useState<CustomCategory | null>(null);
   const [newCategory, setNewCategory] = useState({
     name: '',
+    display_name: '',
     measurement_type: '',
     frequency: 'Daily',
     data_type: 'numeric'
@@ -72,6 +73,7 @@ const CustomCategoryManager = ({ categories, onCategoriesChange }: CustomCategor
       const data = await addCategory({
         user_id: user.id,
         name: newCategory.name.trim(),
+        display_name: newCategory.display_name.trim() || undefined,
         measurement_type: newCategory.measurement_type.trim(),
         frequency: newCategory.frequency,
         data_type: newCategory.data_type
@@ -79,7 +81,7 @@ const CustomCategoryManager = ({ categories, onCategoriesChange }: CustomCategor
       // Refetch categories to ensure the new one with the correct ID and all fields is displayed
       const fetchedCategories = await getCategories(loggingLevel);
       onCategoriesChange(fetchedCategories || []);
-      setNewCategory({ name: '', measurement_type: '', frequency: 'Daily', data_type: 'numeric' });
+      setNewCategory({ name: '', display_name: '', measurement_type: '', frequency: 'Daily', data_type: 'numeric' });
       setIsAddDialogOpen(false);
       
       toast({
@@ -109,6 +111,7 @@ const CustomCategoryManager = ({ categories, onCategoriesChange }: CustomCategor
     try {
       const updatedData = await updateCategory(editingCategory.id, {
         name: editingCategory.name.trim(),
+        display_name: editingCategory.display_name?.trim() || undefined,
         measurement_type: editingCategory.measurement_type.trim(),
         frequency: editingCategory.frequency,
         data_type: editingCategory.data_type
@@ -205,6 +208,18 @@ const CustomCategoryManager = ({ categories, onCategoriesChange }: CustomCategor
                   placeholder={t('customCategoryManager.namePlaceholder', 'e.g., Blood Sugar')}
                   maxLength={50}
                 />
+                <p className="text-xs text-gray-500 mt-1">{t('customCategoryManager.nameHelp', 'Internal identifier used for syncing')}</p>
+              </div>
+              <div>
+                <Label htmlFor="display_name">{t('customCategoryManager.displayNameLabel', 'Display Name (optional, max 100 characters)')}</Label>
+                <Input
+                  id="display_name"
+                  value={newCategory.display_name}
+                  onChange={(e) => setNewCategory({ ...newCategory, display_name: e.target.value.slice(0, 100) })}
+                  placeholder={t('customCategoryManager.displayNamePlaceholder', 'e.g., Morning Blood Sugar Level')}
+                  maxLength={100}
+                />
+                <p className="text-xs text-gray-500 mt-1">{t('customCategoryManager.displayNameHelp', 'Optional custom name shown in the app')}</p>
               </div>
               <div>
                 <Label htmlFor="measurement_type">{t('customCategoryManager.measurementTypeLabel', 'Measurement Type (max 50 characters)')}</Label>
@@ -261,7 +276,10 @@ const CustomCategoryManager = ({ categories, onCategoriesChange }: CustomCategor
           {categories.map((category, index) => (
             <div key={category.id || `UNDEFINED_ID-${index}`} className="flex items-center justify-between p-3 border rounded">
               <div>
-                <div className="font-medium">{category.name}</div>
+                <div className="font-medium">{category.display_name || category.name}</div>
+                {category.display_name && (
+                  <div className="text-xs text-gray-400">({category.name})</div>
+                )}
                 <div className="text-sm text-gray-500">
                   {category.measurement_type} • {category.frequency} • {category.data_type}
                 </div>
@@ -306,7 +324,20 @@ const CustomCategoryManager = ({ categories, onCategoriesChange }: CustomCategor
                   onChange={(e) => setEditingCategory({ ...editingCategory, name: e.target.value.slice(0, 50) })}
                   placeholder={t('customCategoryManager.namePlaceholder', 'e.g., Blood Sugar')}
                   maxLength={50}
+                  disabled
                 />
+                <p className="text-xs text-gray-500 mt-1">{t('customCategoryManager.nameHelp', 'Internal identifier used for syncing')}</p>
+              </div>
+              <div>
+                <Label htmlFor="edit-display_name">{t('customCategoryManager.displayNameLabel', 'Display Name (optional, max 100 characters)')}</Label>
+                <Input
+                  id="edit-display_name"
+                  value={editingCategory.display_name || ''}
+                  onChange={(e) => setEditingCategory({ ...editingCategory, display_name: e.target.value.slice(0, 100) || null })}
+                  placeholder={t('customCategoryManager.displayNamePlaceholder', 'e.g., Morning Blood Sugar Level')}
+                  maxLength={100}
+                />
+                <p className="text-xs text-gray-500 mt-1">{t('customCategoryManager.displayNameHelp', 'Optional custom name shown in the app')}</p>
               </div>
               <div>
                 <Label htmlFor="edit-measurement_type">{t('customCategoryManager.measurementTypeLabel', 'Measurement Type (max 50 characters)')}</Label>

--- a/SparkyFitnessFrontend/src/components/CustomMeasurements.tsx
+++ b/SparkyFitnessFrontend/src/components/CustomMeasurements.tsx
@@ -203,7 +203,7 @@ const CustomMeasurements = () => {
                   <Card key={category.id} className="h-fit">
                     <CardHeader className="pb-3">
                       <CardTitle className="text-sm font-medium">
-                        {category.name}
+                        {category.display_name || category.name}
                       </CardTitle>
                       <p className="text-xs text-muted-foreground">
                         {category.measurement_type} • {category.frequency} • {category.data_type || 'numeric'}
@@ -271,7 +271,7 @@ const CustomMeasurements = () => {
                 >
                   <div>
                     <div className="font-medium">
-                      {measurement.custom_categories.name}: {measurement.value} {measurement.custom_categories.measurement_type}
+                      {measurement.custom_categories.display_name || measurement.custom_categories.name}: {measurement.value} {measurement.custom_categories.measurement_type}
                     </div>
                     <div className="text-sm text-muted-foreground">
                       {new Date(measurement.entry_date).toLocaleDateString()}

--- a/SparkyFitnessFrontend/src/components/reports/ReportsTables.tsx
+++ b/SparkyFitnessFrontend/src/components/reports/ReportsTables.tsx
@@ -104,6 +104,7 @@ interface MeasurementData {
 interface CustomCategory {
   id: string;
   name: string;
+  display_name?: string | null;
   measurement_type: string;
   frequency: string;
   data_type: string;
@@ -546,7 +547,7 @@ const ReportsTables = ({
           <Card key={category.id}>
             <CardHeader>
               <div className="flex items-center justify-between">
-                <CardTitle>{category.name} ({category.measurement_type})</CardTitle>
+                <CardTitle>{category.display_name || category.name} ({category.measurement_type})</CardTitle>
                 <Button
                   onClick={() => onExportCustomMeasurements(category)}
                   variant="outline"

--- a/SparkyFitnessFrontend/src/services/categoryService.ts
+++ b/SparkyFitnessFrontend/src/services/categoryService.ts
@@ -3,6 +3,7 @@ import { apiCall } from "./api";
 interface CustomCategory {
   id: string;
   name: string;
+  display_name?: string | null;
   measurement_type: string;
   frequency: string;
 }
@@ -10,12 +11,14 @@ interface CustomCategory {
 interface NewCategoryData {
   user_id: string;
   name: string;
+  display_name?: string;
   measurement_type: string;
   frequency: string;
 }
 
 interface UpdateCategoryData {
   name?: string;
+  display_name?: string;
   measurement_type?: string;
   frequency?: string;
 }

--- a/SparkyFitnessFrontend/src/services/checkInService.ts
+++ b/SparkyFitnessFrontend/src/services/checkInService.ts
@@ -3,6 +3,7 @@ import { apiCall } from './api';
 export interface CustomCategory {
   id: string;
   name: string;
+  display_name?: string | null;
   measurement_type: string;
   frequency: string;
   data_type: 'numeric' | 'text';
@@ -18,6 +19,7 @@ export interface CustomMeasurement {
   notes?: string;
   custom_categories: {
     name: string;
+    display_name?: string | null;
     measurement_type: string;
     frequency: string;
     data_type: 'numeric' | 'text';

--- a/SparkyFitnessFrontend/src/services/customCategoryService.ts
+++ b/SparkyFitnessFrontend/src/services/customCategoryService.ts
@@ -5,6 +5,7 @@ import { UserLoggingLevel } from '@/utils/logging';
 export interface CustomCategory {
   id: string;
   name: string;
+  display_name?: string | null;
   measurement_type: string;
   frequency: string;
   data_type: string;
@@ -26,7 +27,7 @@ export const getCategories = async (loggingLevel: UserLoggingLevel): Promise<Cus
   }).map((cat: any) => ({ ...cat, id: String(cat.id) })); // Ensure ID is string for valid categories
 };
 
-export const addCategory = async (categoryData: { user_id: string; name: string; measurement_type: string; frequency: string; data_type: string }, loggingLevel: UserLoggingLevel): Promise<CustomCategory> => {
+export const addCategory = async (categoryData: { user_id: string; name: string; display_name?: string; measurement_type: string; frequency: string; data_type: string }, loggingLevel: UserLoggingLevel): Promise<CustomCategory> => {
   const response = await apiCall('/measurements/custom-categories', {
     method: 'POST',
     body: categoryData,
@@ -40,7 +41,7 @@ export const addCategory = async (categoryData: { user_id: string; name: string;
   return { ...response, id: id };
 };
 
-export const updateCategory = async (categoryId: string, categoryData: { name: string; measurement_type: string; frequency: string; data_type: string }, loggingLevel: UserLoggingLevel): Promise<CustomCategory> => {
+export const updateCategory = async (categoryId: string, categoryData: { name?: string; display_name?: string; measurement_type?: string; frequency?: string; data_type?: string }, loggingLevel: UserLoggingLevel): Promise<CustomCategory> => {
   const response = await apiCall(`/measurements/custom-categories/${categoryId}`, {
     method: 'PUT',
     body: categoryData,

--- a/SparkyFitnessFrontend/src/services/customMeasurementService.ts
+++ b/SparkyFitnessFrontend/src/services/customMeasurementService.ts
@@ -3,6 +3,7 @@ import { apiCall } from './api';
 export interface CustomCategory {
   id: string;
   name: string;
+  display_name?: string | null;
   measurement_type: string;
   frequency: string;
   data_type: string;
@@ -18,6 +19,7 @@ export interface CustomMeasurement {
   entry_timestamp: string;
   custom_categories: {
     name: string;
+    display_name?: string | null;
     measurement_type: string;
     frequency: string;
     data_type: string;

--- a/SparkyFitnessFrontend/src/services/reportsService.ts
+++ b/SparkyFitnessFrontend/src/services/reportsService.ts
@@ -128,6 +128,7 @@ export interface ExerciseProgressData {
 export interface CustomCategory {
   id: string;
   name: string;
+  display_name?: string | null;
   measurement_type: string;
   frequency: string;
   data_type: string;

--- a/SparkyFitnessServer/db/migrations/20251112000000_add_display_name_to_custom_categories.sql
+++ b/SparkyFitnessServer/db/migrations/20251112000000_add_display_name_to_custom_categories.sql
@@ -1,0 +1,10 @@
+-- Migration: Add display_name column to custom_categories table
+-- This allows users to set a custom display name (alias) for categories
+-- while keeping the 'name' field as a stable identifier for syncing
+
+-- Add display_name column
+ALTER TABLE custom_categories
+ADD COLUMN display_name VARCHAR(100);
+
+-- Add comment explaining the column purpose
+COMMENT ON COLUMN custom_categories.display_name IS 'User-editable display name for the category. If NULL, the name field is used for display. The name field serves as the stable identifier for syncing and lookups.';


### PR DESCRIPTION
This change allows users to rename custom categories with display names while keeping the original name as a stable identifier for syncing.

Changes:
- Added display_name column to custom_categories table (VARCHAR 100)
- Updated measurementRepository to include display_name in all queries
- Modified API routes to accept display_name parameter
- Updated frontend TypeScript types across all services
- Enhanced UI to show and edit display_name in:
  - CustomCategoryManager: Added display name field with help text
  - CheckIn: Display categories using display_name
  - CustomMeasurements: Show display_name in cards
  - ReportsTables: Use display_name in report headers
- Name field is now read-only in edit dialog (stable sync identifier)
- Display name is optional and falls back to name if not set

This resolves the issue where synced categories from mobile apps could not be renamed without breaking the sync logic.