### PR TITLE
Disable VitePWA auto-registration and exclude API from SW

### DIFF
--- a/SparkyFitnessFrontend/vite.config.ts
+++ b/SparkyFitnessFrontend/vite.config.ts
@@ -42,7 +42,8 @@ export default defineConfig(({ mode }) => {
     react(),
     mode === "development" && componentTagger(),
     VitePWA({
-      registerType: "autoUpdate",
+      registerType: "prompt", // Changed from autoUpdate to prevent automatic registration
+      injectRegister: null, // Don't inject any registration code - we handle it manually in index.html
       manifest: {
         name: "SparkyFitness",
         short_name: "SparkyFitness",


### PR DESCRIPTION
ROOT CAUSE FIXES:
1. VitePWA plugin was auto-generating registerSW.js that unconditionally registered the Service Worker, bypassing our conditional logic in index.html. This caused SW to register even in fresh/incognito sessions.

2. Service Worker was intercepting API requests. When API calls failed due to Authentik's 302 redirects (CORS), the SW caught errors and caused Network Errors instead of letting requests fail properly.

Changes to vite.config.ts:
- Set registerType: "prompt" instead of "autoUpdate"
- Set injectRegister: null to disable automatic registration script
- We now handle ALL SW registration manually via index.html logic

Changes to sw.js:
- Exclude ALL API paths from SW interception (/api/, /openid/, /health-data/, /uploads/)
- API requests now bypass SW completely, allowing Authentik to handle auth
- Bump cache version to v3

This should fix iOS authentication flow completely.