### PR TITLE
Add iOS build workflow for IPA generation

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,93 @@
+name: Build iOS IPA
+
+on:
+  push:
+#    branches: [ main ]
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install npm dependencies
+      run: |
+        cd SparkyFitnessMobile
+        npm install
+
+    - name: Cache CocoaPods
+      uses: actions/cache@v4
+      with:
+        path: SparkyFitnessMobile/ios/Pods
+        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pods-
+
+    - name: Install CocoaPods dependencies
+      run: |
+        cd SparkyFitnessMobile/ios
+        pod install
+
+    - name: Build iOS app (unsigned)
+      run: |
+        cd SparkyFitnessMobile/ios
+        xcodebuild -workspace SparkyFitnessMobile.xcworkspace \
+          -scheme SparkyFitnessMobile \
+          -configuration Release \
+          -sdk iphoneos \
+          -archivePath $PWD/build/SparkyFitnessMobile.xcarchive \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          archive
+
+    - name: Create IPA
+      run: |
+        cd SparkyFitnessMobile/ios
+        mkdir -p Payload
+        cp -r build/SparkyFitnessMobile.xcarchive/Products/Applications/SparkyFitnessMobile.app Payload/
+        zip -r SparkyFitnessMobile.ipa Payload
+        mv SparkyFitnessMobile.ipa build/
+
+    - name: Get IPA path
+      id: ipa
+      run: |
+        IPA_PATH="SparkyFitnessMobile/ios/build/SparkyFitnessMobile.ipa"
+        echo "path=$IPA_PATH" >> $GITHUB_OUTPUT
+        echo "name=SparkyFitnessMobile.ipa" >> $GITHUB_OUTPUT
+
+    - name: Get version from package.json
+      id: version
+      run: |
+        VERSION=$(node -p "require('./SparkyFitnessMobile/package.json').version")
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Upload IPA as artifact
+      if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+      uses: actions/upload-artifact@v4
+      with:
+        name: SparkyFitnessMobile-iOS-v${{ steps.version.outputs.version }}
+        path: ${{ steps.ipa.outputs.path }}
+
+    - name: Create Release
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ${{ steps.ipa.outputs.path }}
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Build unsigned IPA for AltStore distribution
- Uses macOS runner with Xcode
- Mirrors Android workflow structure
- Triggers on tags (v*) and manual dispatch
- Uploads IPA as artifact and creates GitHub releases