### PR TITLE
Remove healthkit device capability requirement for iPad compatibility

### DIFF
--- a/SparkyFitnessMobile/ios/SparkyFitnessMobile/Info.plist
+++ b/SparkyFitnessMobile/ios/SparkyFitnessMobile/Info.plist
@@ -52,9 +52,5 @@
 	<string>This app needs access to your health data to track and sync your fitness metrics including steps, heart rate, calories, weight, and other health information to help you monitor your wellness goals.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>This app may write health data to HealthKit for tracking purposes.</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>healthkit</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
- Remove duplicate UIRequiredDeviceCapabilities with healthkit requirement
- Keeps arm64 requirement for modern devices
- Allows app to run on iPad even without full HealthKit support
- App will gracefully handle missing HealthKit features