### PR TITLE
Fix NitroModules version to match healthkit dependency requirements

### DIFF
--- a/SparkyFitnessMobile/package.json
+++ b/SparkyFitnessMobile/package.json
@@ -21,14 +21,14 @@
     "react-native-background-fetch": "^4.2.8",
     "react-native-gesture-handler": "^2.28.0",
     "@kingstinct/react-native-healthkit": "^12.1.0",
-    "nitro-modules": "^0.13.1",
+    "nitro-modules": "^0.30.0",
     "react-native-health-connect": "^3.3.3",
     "react-native-safe-area-context": "^5.6.0",
     "react-native-screens": "^4.13.1",
     "axios": "^1.13.0"
   },
   "devDependencies": {
-    "react-native-nitro-modules": "^0.13.1",
+    "react-native-nitro-modules": "^0.30.0",
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",


### PR DESCRIPTION
Update nitro-modules and react-native-nitro-modules from 0.13.1 to 0.30.0 to meet the peer dependency requirement of @kingstinct/react-native-healthkit which requires react-native-nitro-modules >= 0.30.

This fixes the npm install failure on both iOS and Android builds.