### PR TITLE
Fix package name: use react-native-nitro-modules not nitro-modules

### DIFF
--- a/SparkyFitnessMobile/ios/Podfile
+++ b/SparkyFitnessMobile/ios/Podfile
@@ -9,7 +9,7 @@ platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
 # Add NitroModules support for @kingstinct/react-native-healthkit
-pod 'NitroModules', :path => '../node_modules/nitro-modules'
+pod 'NitroModules', :path => '../node_modules/react-native-nitro-modules'
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil

--- a/SparkyFitnessMobile/package.json
+++ b/SparkyFitnessMobile/package.json
@@ -21,7 +21,6 @@
     "react-native-background-fetch": "^4.2.8",
     "react-native-gesture-handler": "^2.28.0",
     "@kingstinct/react-native-healthkit": "^12.1.0",
-    "nitro-modules": "^0.30.0",
     "react-native-health-connect": "^3.3.3",
     "react-native-safe-area-context": "^5.6.0",
     "react-native-screens": "^4.13.1",


### PR DESCRIPTION
Remove non-existent 'nitro-modules' package and update Podfile to point to the correct 'react-native-nitro-modules' path.

The standalone 'nitro-modules' package doesn't exist - the correct package is 'react-native-nitro-modules' which is already in devDependencies.