### PR TITLE
Fix iOS workflow cache to use Podfile instead of Podfile.lock

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: SparkyFitnessMobile/ios/Pods
-        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+        key: ${{ runner.os }}-pods-${{ hashFiles('SparkyFitnessMobile/ios/Podfile', 'SparkyFitnessMobile/package.json') }}
         restore-keys: |
           ${{ runner.os }}-pods-
 


### PR DESCRIPTION
Change cache key from hashing Podfile.lock (which may not exist) to hashing Podfile and package.json (which always exist). This prevents the hashFiles() failure during workflow execution.

The cache will still be properly invalidated when dependencies change since both Podfile and package.json affect the CocoaPods installation.